### PR TITLE
更新par.spacing语法使用

### DIFF
--- a/templates/shared.typ
+++ b/templates/shared.typ
@@ -56,7 +56,7 @@
   show link: underline
   set math.vec(delim: "[")
   set math.mat(delim: "[")
-  show par: set block(spacing: line_height)
+  set par(spacing: line_height)
 
   doc
 }


### PR DESCRIPTION
### 问题位置
- `templates` 文件夹中的shared.typ
- 使用了已弃用的语法 `set block(spacing: ..)`，导致无法兼容 Typst v0.12.0。

### 问题原因
从 [Typst v0.12.0](https://github.com/typst/typst/releases/tag/v0.12.0) 开始，`set block(spacing: ..)` 语法被移除，替代为 `par.spacing`。

### 更新内容
- 更新了代码中的段落间距设置。

### 可能的影响
- 该更改仅适用于 Typst v0.12.0 及更高版本，旧版本可能无法识别。

### 测试
- 已通过本地生成的文档进行测试，确保示例代码在 Typst v0.12.0 中正常运行。